### PR TITLE
Improve publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ maven { url "https://dl.bintray.com/caarmen/maven/" }
 
 Declare the dependency:
 ```
-compile 'ca.rmen:lib-sunrise-sunset:1.1.1'
+compile 'ca.rmen:lib-sunrise-sunset:1.1.2'
 ```
 Maven:
 ------
@@ -40,7 +40,7 @@ Declare the dependency:
 <dependency>
  <groupId>ca.rmen</groupId>
  <artifactId>lib-sunrise-sunset</artifactId>
- <version>1.1.1</version>
+ <version>1.1.2</version>
  <scope>compile</scope>
 </dependency>
 ```
@@ -84,12 +84,12 @@ or build it with `mvn clean package`, which will place it in `cli/target`.
 Usage:
 
 ```
-java -jar /path/to/sunrise-sunset-cli-1.1.1.jar <timezone> <yyyyMMdd> <latitude> <longitude>
+java -jar /path/to/sunrise-sunset-cli-1.1.2.jar <timezone> <yyyyMMdd> <latitude> <longitude>
 ```
 
 Example usage:
 ```
-java -jar /path/to/sunrise-sunset-cli-1.1.1.jar Europe/Paris 20171125 48.8 2.35
+java -jar /path/to/sunrise-sunset-cli-1.1.2.jar Europe/Paris 20171125 48.8 2.35
 Current time at: 48.8,2.35:
   2017-11-25 18:01:42 Central European Time
 Current day period is NAUTICAL_TWILIGHT

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>ca.rmen</groupId>
 		<artifactId>sunrise-sunset</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 	</parent>
 
 	<artifactId>sunrise-sunset-cli</artifactId>

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 logprefix=$0
-echo "$logprefix: Rebuilding project..."
+echo "${logprefix}: Rebuilding project..."
 mvn clean package
-echo "$logprefix: Project rebuilt".
-echo "$logprefix: Extracting version from pom file..."
-version=`mvn -q exec:exec -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive`
-echo "$logprefix: Version is $version."
-echo "$logprefix: Installing to local maven repository..."
+echo "${logprefix}: Project rebuilt".
+echo "${logprefix}: Extracting version from pom file..."
+version=$(mvn -q exec:exec -Dexec.executable="echo" -Dexec.args="\${project.version}" --non-recursive)
+echo "${logprefix}: Version is $version."
+echo "${logprefix}: Installing to local maven repository..."
 mvn install -f publish.pom
-mvn install:install-file -Dfile=library/target/lib-sunrise-sunset-$version.jar -Djavadoc=library/target/lib-sunrise-sunset-$version-javadoc.jar -Dsources=library/target/lib-sunrise-sunset-$version-sources.jar
-echo "$logprefix: Done."
+mvn install:install-file \
+  -Dfile="library/target/lib-sunrise-sunset-$version.jar" \
+  -Djavadoc="library/target/lib-sunrise-sunset-${version}-javadoc.jar" \
+  -Dsources="library/target/lib-sunrise-sunset-${version}-sources.jar"
+echo "${logprefix}: Done."

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 logprefix=$0
 echo "${logprefix}: Rebuilding project..."
-mvn clean package
+mvn clean
+if [ "${GPGKEY}" != "" ]
+then
+  # To sign the package, use the following command to find the name of your gpg key:
+  # gpg --list-signatures --keyid-format 0xshort
+  # The name of the key is the first token after "sig 3".
+  # See https://central.sonatype.org/publish/requirements/gpg/#listing-keys for more info.
+  # Set the environment variable GPGKEY to the name of the key to use.
+  mvn -Dgpg.keyname="${GPGKEY}" package gpg:sign
+else
+  mvn package
+fi
 echo "${logprefix}: Project rebuilt".
 echo "${logprefix}: Extracting version from pom file..."
 version=$(mvn -q exec:exec -Dexec.executable="echo" -Dexec.args="\${project.version}" --non-recursive)

--- a/install.sh
+++ b/install.sh
@@ -24,3 +24,34 @@ mvn install:install-file \
   -Djavadoc="library/target/lib-sunrise-sunset-${version}-javadoc.jar" \
   -Dsources="library/target/lib-sunrise-sunset-${version}-sources.jar"
 echo "${logprefix}: Done."
+
+# Release
+echo "${logprefix}: Creating bundle for distribution"
+# Copy the already signed library artifacts to a temporary directory.
+tmpdir=$(mktemp --directory -t bundle -p /tmp/)
+destdir="${tmpdir}/ca/rmen/lib-sunrise-sunset/${version}"
+srcdir=library/target
+bundle_file="target/bundle-${version}.jar"
+mkdir -p "${destdir}"
+cp -pr "${srcdir}"/*.jar* "${destdir}"
+
+# Copy the publish.pom file and to the target diretory and sign it.
+cp publish.pom "${destdir}/lib-sunrise-sunset-${version}.pom"
+if [ "${GPGKEY}" != "" ]
+then
+  gpg --local-user "${GPGKEY}" -ab "${destdir}/lib-sunrise-sunset-${version}.pom"
+fi
+
+# Add md5 and sha files for all the artifacts.
+for file in "${destdir}"/*.jar "${destdir}"/*.asc "${destdir}"/*.pom
+do
+  md5 -q "${file}" > "${file}".md5
+  for algo in 1 256 512
+  do
+    shasum -a "${algo}" "${file}" | awk '{ print $1 }' > "${file}.sha${algo}"
+  done
+done
+
+# Create a bundle containing everything (jar, asc, pom files, and all their md5 and sha corresponding files).
+jar cfM "${bundle_file}" -C "${tmpdir}" ca
+echo "${logprefix} created ${bundle_file}"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 logprefix=$0
 echo "$logprefix: Rebuilding project..."
 mvn clean package

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -27,12 +27,12 @@
 	<parent>
 		<groupId>ca.rmen</groupId>
 		<artifactId>sunrise-sunset</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 	</parent>
 
 	<artifactId>lib-sunrise-sunset</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<name>lib-sunrise-sunset</name>
 	<url>http://rmen.ca</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	<groupId>ca.rmen</groupId>
 	<artifactId>sunrise-sunset</artifactId>
 	<packaging>pom</packaging>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<name>sunrise-sunset</name>
 	<description>Provides methods to determine the sunrise, sunset, civil twilight,nautical twilight, and astronomical twilight times of a given location, or if it is currently day or night at a given location.</description>
 	<url>http://github.com/caarmen/SunriseSunset</url>

--- a/publish.pom
+++ b/publish.pom
@@ -24,7 +24,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.rmen</groupId>
 	<artifactId>lib-sunrise-sunset</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<packaging>jar</packaging>
 
 	<name>sunrise-sunset</name>


### PR DESCRIPTION
* Bump the version to 1.1.2.
* Correct shellcheck errors in `install.sh`.
* Make `install.sh` use `mvn gpg:sign` if the `GPGKEY` environment variable is set.
* Make `install.sh`create a bundle jar file suitable for uploading to maven central.